### PR TITLE
force summary to be a one-liner

### DIFF
--- a/tic_tac_toe.js
+++ b/tic_tac_toe.js
@@ -719,15 +719,10 @@ function getAppSummary() {
   ).length;
   const wins = completed_games.length - ties;
   return (
-    "Stats:" +
-    "\nRunning Games: " +
-    active_games.length +
-    "\nCompleted Games: " +
-    completed_games.length +
-    "\nWins: " +
-    wins +
-    "\nTies: " +
-    ties
+    active_games.length + " running, " +
+    completed_games.length + " completed games, " +
+    wins + " wins, " +
+    ties + " ties"
   );
 }
 


### PR DESCRIPTION
our spec currently allows only one line.
even if implementation are a bit more generous,
the official example should follow the spec.

closes #3 